### PR TITLE
Increase allowed time for jobs

### DIFF
--- a/enqueue/enqueueMain.py
+++ b/enqueue/enqueueMain.py
@@ -38,11 +38,12 @@ prefix = getenv('QUEUE_PREFIX', '') # Gets (optional) QUEUE_PREFIX environment v
 prefixed_our_name = prefix + OUR_NAME
 
 
-JOB_TIMEOUT = '360s' if prefix else '180s' # Then a running job (taken out of the queue) will be considered to have failed
+# NOTE: Large lexicons like UGL and UAHL seem to be the longest-running jobs
+JOB_TIMEOUT = '480s' if prefix else '240s' # Then a running job (taken out of the queue) will be considered to have failed
     # NOTE: This is only the time until webhook.py returns after preprocessing and submitting the job
     #           -- the actual conversion jobs might still be running.
-CALLBACK_TIMEOUT = '480s' if prefix else '240s' # Then a running callback job (taken out of the queue) will be considered to have failed
-
+CALLBACK_TIMEOUT = '1200s' if prefix else '600s' # Then a running callback job (taken out of the queue) will be considered to have failed
+    # RJH: 480s fails on UGL upload for my slow internet (600s fails even on mini UGL upload!!!)
 
 # Get the redis URL from the environment, otherwise use a local test instance
 redis_hostname = getenv('REDIS_HOSTNAME', 'redis')

--- a/enqueue/requirements.txt
+++ b/enqueue/requirements.txt
@@ -2,4 +2,4 @@ Flask==1.0.2
 rq==0.13.0
 gunicorn==19.9.0
 statsd==3.3.0
-watchtower==0.5.4
+watchtower==0.5.5


### PR DESCRIPTION
Callback processing for large projects can take time. (These increases still might not be enough for projects like the UGL.)

Also upgrades Watchtower logging package.